### PR TITLE
Removed "Face" option from clothing stores

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -45,7 +45,7 @@
                         <div class="clothing-menu-option-item-header" id="current-model"><p>mp_m_freemode_01</p></div>
                     </div>
                 </div>
-                <div class="clothing-menu-option" data-type="face">
+                <div class="clothing-menu-option" id="faceoption" data-type="face">
                     <div class="clothing-menu-option-header"><p>Face</p></div>
                     <div class="clothing-menu-option-item">
                         <div class="clothing-menu-option-item-header" data-headertype="item-header"><p>Type</p></div>

--- a/html/script.js
+++ b/html/script.js
@@ -352,6 +352,13 @@ QBClothing.Open = function(data) {
         if (menu.selected) {
             $(".clothing-menu-header").append('<div class="clothing-menu-header-btn '+menu.menu+'Tab selected" data-category="'+menu.menu+'"><p>'+menu.label+'</p></div>')
             $(".clothing-menu-"+menu.menu+"-container").css({"display":"block"});
+            
+            if (menu.label == "Clothing") {
+                $("#faceoption").css("display", "none");
+            } else {
+                $("#faceoption").css("display", "block");
+            }
+
             selectedTab = "." + menu.menu + "Tab";
             lastCategory = menu.menu;
 


### PR DESCRIPTION
Not the best implementation but it works

If label is "Clothing" then no Face Option
`{menu = "character", label = "Clothing"`

If any other label (eg. Character) then shows Face Option
`{menu = "character", label = "Character"`

For issue #22 and #18 