### PR TITLE
refactor(cam): Unify Camera to Orbit & Overall Fixes

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,7 +1,8 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local creatingCharacter = false
 local cam = -1
-local heading = 332.219879
+local headingToCam = GetEntityHeading(PlayerPedId())
+local camOffset = 2
 local zoom = "character"
 local customCamLocation = nil
 local PlayerData = {}
@@ -307,6 +308,15 @@ function DrawText3Ds(x, y, z, text)
     ClearDrawOrigin()
 end
 
+function GetPositionByRelativeHeading(ped, head, dist)
+    local pedPos = GetEntityCoords(PlayerPedId())
+
+    local finPosx = pedPos.x + math.cos(head * (math.pi / 180)) * dist
+    local finPosy = pedPos.y + math.sin(head * (math.pi / 180)) * dist
+
+    return finPosx, finPosy
+end
+
 Citizen.CreateThread(function()
     for k, v in pairs (Config.Stores) do
         if Config.Stores[k].shopType == "clothing" then
@@ -474,16 +484,32 @@ end)
 
 RegisterNUICallback('rotateRight', function()
     local ped = PlayerPedId()
-    local heading = GetEntityHeading(ped)
+    local pedPos = GetEntityCoords(ped)
+    local camPos = GetCamCoord(cam)
 
-    SetEntityHeading(ped, heading + 30)
+    local heading = headingToCam
+
+    heading = heading + 2.5
+    headingToCam = heading
+
+    local cx, cy = GetPositionByRelativeHeading(ped, heading, camOffset)
+    SetCamCoord(cam, cx, cy, camPos.z)
+    PointCamAtCoord(cam, pedPos.x, pedPos.y, camPos.z)
 end)
 
 RegisterNUICallback('rotateLeft', function()
     local ped = PlayerPedId()
-    local heading = GetEntityHeading(ped)
+    local pedPos = GetEntityCoords(ped)
+    local camPos = GetCamCoord(cam)
 
-    SetEntityHeading(ped, heading - 30)
+    local heading = headingToCam
+
+    heading = heading - 2.5
+    headingToCam = heading
+
+    local cx, cy = GetPositionByRelativeHeading(ped, heading, camOffset)
+    SetCamCoord(cam, cx, cy, camPos.z)
+    PointCamAtCoord(cam, pedPos.x, pedPos.y, camPos.z)
 end)
 
 firstChar = false
@@ -715,13 +741,16 @@ function enableCam()
         cam = CreateCam('DEFAULT_SCRIPTED_CAMERA', true)
         SetCamActive(cam, true)
         RenderScriptCams(true, false, 0, true, true)
-        SetCamCoord(cam, coords.x, coords.y, coords.z + 0.5)
+        SetCamCoord(cam, coords.x, coords.y, coords.z + 0.2)
         SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()) + 180)
     end
 
     if customCamLocation ~= nil then
         SetCamCoord(cam, customCamLocation.x, customCamLocation.y, customCamLocation.z)
     end
+
+    headingToCam = GetEntityHeading(PlayerPedId()) + 90
+    camOffset = 2.0
 end
 
 RegisterNUICallback('rotateCam', function(data)
@@ -742,19 +771,32 @@ end)
 
 RegisterNUICallback('setupCam', function(data)
     local value = data.value
+    local pedPos = GetEntityCoords(PlayerPedId())
 
     if value == 1 then
-        local coords = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0, 0.75, 0)
-        SetCamCoord(cam, coords.x, coords.y, coords.z + 0.65)
+        local coords = GetCamCoord(cam)
+		camOffset = 0.75
+		local cx, cy = GetPositionByRelativeHeading(PlayerPedId(), headingToCam, camOffset)
+        SetCamCoord(cam, cx, cy, pedPos.z + 0.65)
+        PointCamAtCoord(cam, pedPos.x, pedPos.y, pedPos.z + 0.65)
     elseif value == 2 then
-        local coords = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0, 1.0, 0)
-        SetCamCoord(cam, coords.x, coords.y, coords.z + 0.2)
+        local coords = GetCamCoord(cam)
+		camOffset = 1.0
+		local cx, cy = GetPositionByRelativeHeading(PlayerPedId(), headingToCam, camOffset)
+        SetCamCoord(cam, cx, cy, pedPos.z + 0.2)
+        PointCamAtCoord(cam, pedPos.x, pedPos.y, pedPos.z + 0.2)
     elseif value == 3 then
-        local coords = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0, 1.0, 0)
-        SetCamCoord(cam, coords.x, coords.y, coords.z + -0.5)
+        local coords = GetCamCoord(cam)
+		camOffset = 1.0
+		local cx, cy = GetPositionByRelativeHeading(PlayerPedId(), headingToCam, camOffset)
+        SetCamCoord(cam, cx, cy, pedPos.z + -0.5)
+        PointCamAtCoord(cam, pedPos.x, pedPos.y, pedPos.z + -0.5)
     else
-        local coords = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0, 2.0, 0)
-        SetCamCoord(cam, coords.x, coords.y, coords.z + 0.5)
+        local coords = GetCamCoord(cam)
+		camOffset = 2.0
+		local cx, cy = GetPositionByRelativeHeading(PlayerPedId(), headingToCam, camOffset)
+        SetCamCoord(cam, cx, cy, pedPos.z + 0.2)
+        PointCamAtCoord(cam, pedPos.x, pedPos.y, pedPos.z + 0.2)
     end
 end)
 

--- a/html/index.html
+++ b/html/index.html
@@ -15,9 +15,9 @@
 <body>
     <div class="container">
         <div class="change-camera-buttons">
-            <div class="change-camera-button" data-rotation="left"><i class="fas fa-angle-left"></i></div>
+            <!-- <div class="change-camera-button" data-rotation="left"><i class="fas fa-angle-left"></i></div>
             <div class="change-camera-button" data-rotation="right"><i class="fas fa-angle-right"></i></div>
-            <div class="change-camera-footer"><p>Camera Rotate</p></div>
+            <div class="change-camera-footer"><p>Camera Rotate</p></div> -->
         </div>
         <div class="clothing-menu-container">
             <div class="clothing-menu-header">
@@ -27,7 +27,8 @@
             </div>
 
             <div class="clothing-menu-header-cameras">
-                <div class="clothing-menu-header-camera-btn" data-value="1"><i class="fas fa-horse-head"></i></i></div>
+                <div class="clothing-menu-header-camera-btn" data-value="0"><i class="fas fa-child"></i></i></div>
+                <div class="clothing-menu-header-camera-btn" data-value="1"><i class="fas fa-user-alt"></i></i></div>
                 <div class="clothing-menu-header-camera-btn" data-value="2"><i class="fas fa-tshirt"></i></div>
                 <div class="clothing-menu-header-camera-btn" data-value="3"><i class="fa fa-socks"></i></div>
             </div>

--- a/html/style.css
+++ b/html/style.css
@@ -40,6 +40,7 @@
 
 .clothing-menu-header-btn:hover {
     color: #444444;
+    cursor: pointer;
 }
 
 .selected {
@@ -65,7 +66,7 @@
     position: relative;
     height: 55%;
     top: 3.2vh;
-    width: 33.33%;
+    width: 24%;
     float: left;
     color: #ededed;
     text-align: center;
@@ -79,6 +80,7 @@
 
 .clothing-menu-header-camera-btn:hover {
     color: #444444;
+    cursor: pointer;
 }
 
 .clothing-menu-header-camera-btn > i {
@@ -124,6 +126,7 @@
 
 .clothing-menu-outfit-option-button:hover {
     background-color: #444444;
+    cursor: pointer;
 }
 
 .clothing-menu-outfit-option-button > p {
@@ -149,6 +152,7 @@
 
 .clothing-menu-myOutfit-option-button:hover {
     background-color: #444444;
+    cursor: pointer;
 }
 
 .clothing-menu-myOutfit-option-button > p {
@@ -193,7 +197,7 @@
     left: 0.3vh;
     right: 0;
     top: 9vh;
-    height: 77vh;
+    height: 86vh;
     width: 92%;
     overflow-y: scroll !important;
 }
@@ -205,7 +209,7 @@
     left: 0.3vh;
     right: 0;
     top: 9vh;
-    height: 90vh;
+    height: 86vh;
     width: 92%;
     overflow-y: scroll !important;
 }
@@ -217,7 +221,7 @@
     left: 0.3vh;
     right: 0;
     top: 9vh;
-    height: 77vh;
+    height: 86vh;
     width: 92%;
     overflow-y: scroll !important;
 }
@@ -287,6 +291,7 @@
 
 .clothing-menu-option-item-left:hover {
     background-color: #444444;
+    cursor: pointer;
 }
 
 .clothing-menu-option-item-right {
@@ -305,6 +310,7 @@
 
 .clothing-menu-option-item-right:hover {
     background-color: #444444;
+    cursor: pointer;
 }
 
 .item-number {
@@ -358,6 +364,7 @@
 
 .clothing-menu-option-button:hover {
     background-color: #444444;
+    cursor: pointer;
 }
 
 .clothing-menu-option-button > p {
@@ -405,6 +412,7 @@
 
 .clothing-menu-save-outfit-name-button:hover {
     background: #444444;
+    cursor: pointer;
 }
 
 .clothing-menu-save-outfit-name-button > p {
@@ -490,6 +498,7 @@
 
 .change-camera-button:hover {
     background: #dc143c;
+    cursor: pointer;
 }
 
 .change-camera-button > i {


### PR DESCRIPTION
- Removes the rotate camera buttons at the top
- Changes A & D to an orbiting camera, similar to esx_skin
- Adds a header button to return to a full body view
- Makes buttons use the `cursor: pointer;` on hover to signify it as clickable
- Fixes weird menu length vh