### PR TITLE
Prop Knockoff Toggle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -373,6 +373,14 @@ Citizen.CreateThread(function()
             EndTextCommandSetBlipName(surgeonShop)
         end
     end
+
+    if not Config.headKnockOff then
+        while true do
+            SetPedCanLosePropsOnDamage(PlayerPedId(), false, 0)
+            Wait(1)
+        end
+    end
+    
 end)
 
 RegisterNetEvent('qb-clothing:client:getOutfits', function(requiredJob, gradeLevel)

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,8 @@
 Config = Config or {}
 
+-- Should head props get knocked off?
+Config.headKnockOff = true -- Set to false to prevent hat/glasses from being knocked off
+
 Config.WomanPlayerModels = {
     'mp_f_freemode_01',
     'a_f_m_beach_01',


### PR DESCRIPTION
Simple code edit that allows users to toggle whether or not props get knocked off the player's head