### PR TITLE
Fixing clothing disappearance after closing menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -945,6 +945,9 @@ function closeMenu()
         action = "close",
     })
     disableCam()
+    resetClothing(json.decode(previousSkinData))
+    skinData = json.decode(previousSkinData)
+    previousSkinData = {}
 end
 
 RegisterNUICallback('resetOutfit', function()


### PR DESCRIPTION
When hitting cancel, clothing data seemed to turn to default ped. 

Just a quick fix to return to previous appearance