### PR TITLE
🐛 Minor bugfix with custom camera positioning (sets the heading of the camera to the vector4 W vector) 

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -880,6 +880,7 @@ function enableCam()
 
     if customCamLocation ~= nil then
         SetCamCoord(cam, customCamLocation.x, customCamLocation.y, customCamLocation.z)
+        SetCamRot(cam, 0.0, 0.0, customCamLocation.w) -- this uses the vector4 W vector as a heading for the camera so you can set the specific starting point of it
     end
 
     headingToCam = GetEntityHeading(PlayerPedId()) + 90


### PR DESCRIPTION
sets the camera rotation to the requested custom heading set by the vector4 W vector within the config.lua file (is this intended?)

**Describe Pull request**
the config.lua is using a vector4 position for the camera (i assume this is intended to use a heading value as the W vector in the vector4) this will allow the camera position and heading to be set completely from the vector4 and fixes any issues with unexpected camera positioning (please disregard this PR if the W vector of the vector4 is **not** used in this manner. )

If your PR is to fix an issue mention that issue here
the camera is not set to a customized "heading" due to the w vector not being used programmatically. this fixes this and allows the config.lua to set the exact position and heading of said camera during use.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
yes
- Does your code fit the style guidelines? [yes/no]
yes
- Does your PR fit the contribution guidelines? [yes/no]
yes
