### PR TITLE
feat(save-callback): allow external resources to be aware of clothing…

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1088,6 +1088,7 @@ RegisterNUICallback('close', function(_, cb)
     creatingCharacter = false
     disableCam()
     FreezeEntityPosition(PlayerPedId(), false)
+    TriggerEvent('qb-clothing:client:onMenuClose')
     cb('ok')
 end)
 


### PR DESCRIPTION
**Describe Pull request**
Currently, we can track when the menu has been opened (to allow other resources to be aware if there is already a clothing menu open). We are unable to track when that menu has been closed, which means we can't keep state of the clothing menu being opened or closed.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No (Be honest)
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
